### PR TITLE
Hide long milestone labels

### DIFF
--- a/CODE_DIFFERENCES.md
+++ b/CODE_DIFFERENCES.md
@@ -17,3 +17,6 @@
 - `ExpandIcon.svelte` - pass in onClick to filter issue by icon
 - `LinkIcon.svelte` - pass in onClick to filter issue by icon
 - `PullRequestIcon.svelte` - pass in onClick to filter issue by icon
+
+#### Hide overflow from long milestone names
+- 'Tag.svelte' - hide overflow from milestone labels

--- a/packages/board/src/components/Tag.svelte
+++ b/packages/board/src/components/Tag.svelte
@@ -62,6 +62,7 @@
     line-height: 20px;
     white-space: nowrap;
 
+    overflow: hidden;
     color: white;
     background: #fafafa;
     border-radius: 4px;


### PR DESCRIPTION
hide overflow of long milestone names as it goes outside the card css